### PR TITLE
Fix SessionStart Hook installation timing

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -15,7 +15,7 @@ Hooks are defined in `.claude/settings.json` following the [official documentati
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "*",
+        "matcher": "startup",
         "hooks": [
           {
             "type": "command",
@@ -28,6 +28,8 @@ Hooks are defined in `.claude/settings.json` following the [official documentati
 }
 ```
 
+The `"matcher": "startup"` ensures the hook only runs on new session initialization, not on resume/clear/compact events.
+
 ### What it Does
 
 The SessionStart hook automatically installs development tools in **web/iOS environments only**:
@@ -36,11 +38,11 @@ The SessionStart hook automatically installs development tools in **web/iOS envi
 - **shellcheck v0.10.0** - Shell script linter
 - **bats-core v1.11.0** - Bash Automated Testing System
 
-**Invocation Source Detection** (Optimized):
-- **startup**: First-time session initialization → **Auto-install tools**
-- **resume**: Resume from `/resume` or `--resume` → **Skip installation** (tools already available)
-- **clear**: After `/clear` command → **Skip installation** (tools already available)
-- **compact**: Auto/manual compaction → **Skip installation** (tools already available)
+**Matcher-Based Triggering**:
+- **startup**: New session initialization → **Hook runs** (auto-install tools)
+- **resume**: Resume from `/resume` or `--resume` → **Hook does NOT run**
+- **clear**: After `/clear` command → **Hook does NOT run**
+- **compact**: Auto/manual compaction → **Hook does NOT run**
 
 **Environment Detection**:
 - **Web/iOS** (`CLAUDE_CODE_REMOTE=true`): Auto-install tools to `~/.local/bin/`
@@ -99,19 +101,18 @@ Test the hook script manually:
 When you start a new Claude Code session:
 
 1. Claude Code reads `.claude/settings.json` (and `.claude/settings.local.json` if exists)
-2. SessionStart hooks are triggered automatically
-3. **The hook script detects invocation source** from JSON input (stdin)
-4. **If `source == "startup"`**: Install missing tools to `~/.local/bin/`
-5. **If `source != "startup"`**: Skip installation (tools already available from initial startup)
-6. Tools are ready for `make fmt`, `make lint`, etc.
+2. **Only on `startup` events**: SessionStart hook is triggered (matcher: `"startup"`)
+3. **On `resume/clear/compact` events**: Hook does NOT run (filtered by matcher)
+4. Hook script installs missing tools to `~/.local/bin/` (web/iOS only)
+5. Tools are ready for `make fmt`, `make lint`, etc.
 
 ### Optimization Benefits
 
-**Performance**: Installation tasks only run once at first startup, not on every session resume/clear/compact.
+**Performance**: Matcher-based filtering ensures installation tasks only run once at first startup, not on every session resume/clear/compact.
 
 **Reliability**: Existing tools remain available across session operations without redundant reinstallation.
 
-**Backward Compatibility**: Falls back to `startup` behavior if JSON input is unavailable (e.g., older Claude Code versions).
+**Simplicity**: No need for complex JSON parsing logic - Claude Code's matcher system handles event filtering natively.
 
 ### Notes
 

--- a/.claude/scripts/session-start.sh
+++ b/.claude/scripts/session-start.sh
@@ -5,11 +5,9 @@
 # This hook runs automatically when a Claude Code session starts.
 # It ensures development tools (shfmt, shellcheck, bats-core) are available.
 #
-# Invocation Sources:
-# - startup: New session (performs full installation)
-# - resume: Resume/continue session (skips installation)
-# - clear: Clear command (skips installation)
-# - compact: Compaction operation (skips installation)
+# Trigger: Only on 'startup' events (matcher configured in .claude/settings.json)
+# - startup: New session initialization (this hook runs)
+# - resume/clear/compact: Other events (this hook does NOT run)
 #
 # Environment Detection:
 # - CLAUDE_CODE_REMOTE=true: Web/iOS environment (auto-install tools)
@@ -18,43 +16,7 @@
 
 set -euo pipefail
 
-# Parse hook input JSON to detect invocation source
-# Input format: {"source": "startup"|"resume"|"clear"|"compact", ...}
-detect_invocation_source() {
-  local input=""
-
-  # Read stdin if available (timeout after 0.1s)
-  if read -t 0.1 -r input && [[ -n "${input}" ]]; then
-    # Try jq if available
-    if command -v jq > /dev/null 2>&1; then
-      local source
-      source=$(echo "${input}" | jq -r '.source // "unknown"' 2> /dev/null || echo "unknown")
-      if [[ -n "${source}" && "${source}" != "unknown" ]]; then
-        echo "${source}"
-        return 0
-      fi
-    fi
-
-    # Fallback: basic bash JSON parsing
-    if [[ "${input}" =~ \"source\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
-      echo "${BASH_REMATCH[1]}"
-      return 0
-    fi
-  fi
-
-  # Default to startup if stdin is not available or parsing failed (backward compatibility)
-  echo "startup"
-}
-
-SOURCE="$(detect_invocation_source)"
-
-# Skip installation for non-startup invocations
-if [[ "${SOURCE}" != "startup" ]]; then
-  echo "[SessionStart] Invoked from '${SOURCE}', skipping installation (tools already available)" >&2
-  exit 0
-fi
-
-echo "[SessionStart] Invoked from 'startup', initializing environment..." >&2
+echo "[SessionStart] Initializing environment..." >&2
 
 # Detect if running in Claude Code web/iOS environment
 is_remote_environment() {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "*",
+        "matcher": "startup",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
Use Claude Code's native matcher system to ensure the SessionStart hook only runs on actual session startup, not on resume/clear/compact events.

Changes:
- .claude/settings.json: Change matcher from "*" to "startup"
- .claude/scripts/session-start.sh: Remove 45 lines of JSON parsing logic
- .claude/README.md: Update documentation to reflect matcher-based approach

Benefits:
- Simpler implementation: No need for stdin parsing and source detection
- More reliable: Uses Claude Code's native event filtering
- Clearer intent: Matcher explicitly shows when hook runs

Reference: https://code.claude.com/docs/en/hooks