### PR TITLE
docs: simplify README for beginner friendliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,284 +1,66 @@
 # Xray-Fusion
 
-A lightweight Xray management tool focused on simple and reliable deployment.
+One-command Xray proxy deployment with automatic certificate management.
 
 [![Tests](https://github.com/xrf9268-hue/xray/actions/workflows/test.yml/badge.svg)](https://github.com/xrf9268-hue/xray/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-## Why Xray-Fusion?
-
-- **Production Ready**: 472 unit tests, ~80% coverage, comprehensive CI/CD
-- **Security First**: RFC-compliant validation, systemd hardening, atomic operations
-- **Zero Config**: One-line install with sensible defaults
-- **Flexible**: Templates for common scenarios, plugin system for extensibility
-- **Reliable**: Automatic backups, SHA256 verification, atomic restore
-- **Well Documented**: ShellDoc API docs, troubleshooting guides, ADRs
-
 ## Quick Start
 
 ```bash
-# Reality-only mode (no domain required)
-curl -sL https://github.com/xrf9268-hue/xray/raw/main/install.sh | bash -s -- --topology reality-only
+# Install (no domain required)
+curl -sL https://raw.githubusercontent.com/xrf9268-hue/xray/main/install.sh | bash -s -- --topology reality-only
 
-# Vision + Reality with auto certificates
-curl -sL https://github.com/xrf9268-hue/xray/raw/main/install.sh | bash -s -- \
-  --topology vision-reality --domain your.domain.com --plugins cert-auto
+# View connection links
+xrf links
+
+# Check status
+xrf status
 ```
 
-**Uninstall**:
-```bash
-curl -sL https://github.com/xrf9268-hue/xray/raw/main/uninstall.sh | bash
-```
+That's it! Copy the link to your client app and connect.
 
-## Installation
+## With Your Own Domain
 
-### Using Templates
-
-Pre-configured templates for common scenarios:
-
-| Template | Topology | Use Case | Plugins |
-|----------|----------|----------|---------|
-| `home` | reality-only | Personal use, single device | - |
-| `office` | vision-reality | Small team (5-20 users) | cert-auto, firewall |
-| `server` | vision-reality | Production (50+ users) | cert-auto, firewall, monitoring |
+If you have a domain with DNS pointing to your server:
 
 ```bash
-# Deploy with template
-curl -sL install.sh | bash -s -- --template home
-
-# Template + custom domain
-curl -sL install.sh | bash -s -- --template office --domain vpn.company.com
-```
-
-### Custom Installation
-
-```bash
-# Basic options
---topology reality-only|vision-reality  # Deployment mode (required)
---domain <domain>                       # Domain (required for vision-reality)
---version <version>                     # Xray version (default: latest)
---plugins <plugin1,plugin2>             # Comma-separated plugin list
-
-# Advanced options
---template <template-id>                # Use predefined template
---uuid <uuid>                           # Custom UUID
---uuid-from-string <string>             # Generate UUID from string
---debug                                 # Enable debug logging
-```
-
-**Examples**:
-```bash
-# Reality-only with firewall
-curl -sL install.sh | bash -s -- --topology reality-only --plugins firewall
-
-# Vision-Reality with specific version
-curl -sL install.sh | bash -s -- \
+curl -sL https://raw.githubusercontent.com/xrf9268-hue/xray/main/install.sh | bash -s -- \
   --topology vision-reality \
-  --domain example.com \
-  --version v1.8.0 \
-  --plugins cert-auto,firewall
+  --domain your.domain.com \
+  --plugins cert-auto
 ```
 
-### Manual Installation
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `xrf status` | Service status |
+| `xrf links` | Connection links |
+| `xrf logs` | View logs |
+| `xrf health` | Health check |
+| `xrf uninstall` | Remove installation |
+
+## Uninstall
 
 ```bash
-# Clone repository
-git clone https://github.com/xrf9268-hue/xray.git
-cd xray-fusion
-
-# Install
-bin/xrf install --topology reality-only
+xrf uninstall
 ```
 
-## Usage
+## Requirements
 
-### Basic Commands
-
-```bash
-# Service status
-bin/xrf status
-
-# Connection links
-bin/xrf links
-
-# View logs
-bin/xrf logs
-bin/xrf logs --follow              # Real-time
-bin/xrf logs --level error         # Filter by level
-bin/xrf logs --since "1 hour ago"  # Time range
-
-# Health check
-bin/xrf health
-```
-
-### Backup & Restore
-
-```bash
-# Create backup
-bin/xrf backup create
-bin/xrf backup create --name pre-upgrade
-
-# List backups
-bin/xrf backup list
-
-# Restore (automatically creates pre-restore backup)
-bin/xrf backup restore <backup-name>
-
-# Verify integrity (SHA256)
-bin/xrf backup verify <backup-name>
-
-# Delete old backups
-bin/xrf backup delete <backup-name>
-```
-
-**Automatic Backups**: Installation automatically creates backups when upgrading existing installations.
-
-### Plugin Management
-
-```bash
-# List plugins
-bin/xrf plugin list
-
-# Enable/disable
-bin/xrf plugin enable cert-auto
-bin/xrf plugin disable cert-auto
-
-# Plugin info
-bin/xrf plugin info cert-auto
-```
-
-**Available Plugins**:
-- `cert-auto`: Automatic TLS certificates (Caddy + Let's Encrypt)
-- `firewall`: Firewall port management
-- `logrotate-obs`: Log rotation and observability
-- `links-qr`: QR code generation for client links
-
-## Client Requirements
-
-### Recommended Client Version
-
-Use Xray-core **v25.10.15 or later** for optimal compatibility. This version includes:
-- **uTLS library fixes** for Chrome fingerprint simulation (critical for stability)
-- Improved connection reliability
-- Enhanced protocol support
-
-### Download
-
-- **Official Releases**: https://github.com/XTLS/Xray-core/releases/latest
-- **Installation Guide**: https://xtls.github.io/en/document/install.html
-
-### Version Check
-
-```bash
-xray version
-```
-
-### Compatibility
-
-| Client Version | Status | Notes |
-|----------------|--------|-------|
-| v25.10.15+ | ✅ Recommended | Includes uTLS Chrome fingerprint fix |
-| v25.9.5 - v25.10.14 | ⚠️ Use with caution | May have connection issues |
-| v1.8.0 - v25.9.4 | ✅ Supported | Minimum required version |
-| < v1.8.0 | ❌ Not supported | Please upgrade |
-
-**Latest Tested**: v25.12.8 (2025-12-09)
-
-### Troubleshooting Client Issues
-
-If you experience connection problems:
-
-1. **Check client version**: `xray version`
-2. **Upgrade if outdated**: Download latest from [releases](https://github.com/XTLS/Xray-core/releases/latest)
-3. **Verify configuration**: Ensure client config matches server-provided links
-4. **Check logs**: `xray run -c config.json` to see detailed error messages
-
-For detailed troubleshooting, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
-
-## Advanced Configuration
-
-### Deployment Modes
-
-**Reality-only**:
-- No domain required
-- SNI camouflage (default: `www.microsoft.com`)
-- Port: 443
-- Ideal for: Personal use
-
-**Vision-Reality**:
-- Domain ownership required
-- Real TLS + Reality fallback
-- Ports: 8443 (Vision), 443 (Reality)
-- Ideal for: Teams, production
-
-### Environment Variables
-
-```bash
-# Xray configuration
-XRAY_SNI=www.microsoft.com       # Reality SNI (camouflage domain)
-XRAY_VISION_PORT=8443            # Vision port (vision-reality mode)
-XRAY_REALITY_PORT=443            # Reality port
-
-# Caddy configuration (cert-auto plugin)
-CADDY_HTTP_PORT=80               # HTTP port for ACME challenge
-CADDY_HTTPS_PORT=8444            # HTTPS port (avoids Vision conflict)
-```
-
-### Port Allocation (vision-reality mode)
-
-- **443**: Reality (recommended, follows official best practices)
-- **8443**: Vision (real TLS)
-- **8444**: Caddy HTTPS (certificate management)
-- **8080**: Caddy fallback (handles non-proxy traffic)
-
-## Development
-
-### Testing
-
-```bash
-# Format code
-make fmt
-
-# Lint
-make lint
-
-# Run all tests
-make test
-
-# Unit tests only
-make test-unit
-```
-
-**Test Framework**: [bats-core](https://github.com/bats-core/bats-core)
-**Coverage**: ~80% (472 unit tests across 6 modules)
-
-### CI/CD
-
-GitHub Actions workflows:
-- 🔍 ShellCheck static analysis
-- 📐 shfmt format validation
-- 🧪 Multi-version Ubuntu testing
-- 🔒 Security scanning
+- Linux (Ubuntu/Debian/CentOS)
+- systemd
+- 64-bit architecture
 
 ## Documentation
 
-- 📖 [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - Troubleshooting guide
-- 🤝 [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
-- 📋 [CHANGELOG.md](CHANGELOG.md) - Version history
-- 🏗️ [AGENTS.md](AGENTS.md) - Development standards and technical details
-- 💡 [CLAUDE.md](CLAUDE.md) - Architecture Decision Records (ADRs)
-
-## System Requirements
-
-- Ubuntu/Debian/CentOS/RHEL
-- systemd
-- curl, unzip
-- 64-bit architecture
+| Document | Description |
+|----------|-------------|
+| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Common issues and solutions |
+| [docs/advanced.md](docs/advanced.md) | Advanced configuration |
+| [docs/adr/](docs/adr/) | Architecture decisions |
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
-
----
-
-**Project Philosophy**: Simple, reliable, production-ready. No unnecessary complexity, comprehensive testing, security-first design.
+MIT

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,99 @@
+# Advanced Configuration
+
+## Installation Options
+
+```bash
+--topology reality-only|vision-reality  # Deployment mode (required)
+--domain <domain>                       # Domain (required for vision-reality)
+--version <version>                     # Xray version (default: latest)
+--plugins <plugin1,plugin2>             # Comma-separated plugin list
+--template <template-id>                # Use predefined template
+--uuid <uuid>                           # Custom UUID
+--debug                                 # Enable debug logging
+```
+
+## Templates
+
+| Template | Topology | Use Case |
+|----------|----------|----------|
+| `home` | reality-only | Personal use |
+| `office` | vision-reality | Small team (5-20 users) |
+| `server` | vision-reality | Production (50+ users) |
+
+```bash
+curl -sL install.sh | bash -s -- --template office --domain vpn.company.com
+```
+
+## Deployment Modes
+
+### Reality-only
+- No domain required
+- SNI camouflage (default: `www.microsoft.com`)
+- Port: 443
+
+### Vision-Reality
+- Domain ownership required
+- Real TLS + Reality fallback
+- Ports: 8443 (Vision), 443 (Reality)
+
+## Plugins
+
+| Plugin | Description |
+|--------|-------------|
+| `cert-auto` | Automatic TLS certificates via Caddy |
+| `firewall` | Firewall port management |
+| `logrotate-obs` | Log rotation |
+| `links-qr` | QR code for client links |
+
+```bash
+xrf plugin list
+xrf plugin enable cert-auto
+xrf plugin info cert-auto
+```
+
+## Backup & Restore
+
+```bash
+xrf backup create
+xrf backup create --name pre-upgrade
+xrf backup list
+xrf backup restore <name>
+xrf backup verify <name>
+```
+
+## Environment Variables
+
+```bash
+XRAY_SNI=www.microsoft.com    # Reality SNI
+XRAY_VISION_PORT=8443         # Vision port
+XRAY_REALITY_PORT=443         # Reality port
+CADDY_HTTP_PORT=80            # ACME challenge
+CADDY_HTTPS_PORT=8444         # Caddy HTTPS
+```
+
+## Port Allocation (vision-reality)
+
+| Port | Service |
+|------|---------|
+| 443 | Reality |
+| 8443 | Vision |
+| 8444 | Caddy HTTPS |
+| 8080 | Caddy fallback |
+
+## Client Requirements
+
+**Recommended**: Xray-core v25.10.15+ (includes uTLS fix)
+
+| Version | Status |
+|---------|--------|
+| v25.10.15+ | ✅ Recommended |
+| v1.8.0 - v25.10.14 | ✅ Supported |
+| < v1.8.0 | ❌ Not supported |
+
+## Development
+
+```bash
+make fmt        # Format
+make lint       # Lint
+make test-unit  # Test
+```


### PR DESCRIPTION
Restructure README following best practices:
- Clear one-liner description
- Minimal quick start (3 commands to working setup)
- Simple commands table
- Move advanced content to docs/advanced.md

Changes:
- README.md: 285 → 66 lines (-77%)
- Added docs/advanced.md for power users

Follows progressive disclosure principle: beginners see simple instructions, advanced users find details in docs/.