### PR TITLE
Harden system user creation

### DIFF
--- a/modules/user/user.sh
+++ b/modules/user/user.sh
@@ -1,6 +1,70 @@
 #!/usr/bin/env bash
+[[ -n "${_XRF_USER_LOADED:-}" ]] && return 0
+readonly _XRF_USER_LOADED=1
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=lib/core.sh
+. "${HERE}/lib/core.sh"
+
+##
+# Ensure a system user and group exist with expected ownership
+#
+# Creates a system group/user pair when missing and validates existing
+# ownership matches the expected primary group.
+#
+# Arguments:
+#   $1 - Username (string, optional, default: xray)
+#   $2 - Group name (string, optional, default: xray)
+#
+# Returns:
+#   0 - User/group exist and are correctly associated
+#   1 - Failed to create or ownership mismatch detected
+##
 user::ensure_system_user() {
   local u="${1:-xray}" g="${2:-xray}"
-  getent group "${g}" > /dev/null 2>&1 || sudo groupadd --system "${g}" || true
-  getent passwd "${u}" > /dev/null 2>&1 || sudo useradd --system --gid "${g}" --home-dir /var/lib/"${u}" --no-create-home --shell /usr/sbin/nologin "${u}" || true
+  local group_entry expected_gid user_entry user_gid
+
+  if ! group_entry="$(getent group "${g}")"; then
+    core::log info "creating system group" "$(printf '{"group":"%s"}' "${g}")"
+    if ! sudo groupadd --system "${g}"; then
+      core::log error "failed to create system group" "$(printf '{"group":"%s","hint":"ensure permission to create groups or create manually"}' "${g}")"
+      return 1
+    fi
+    if ! group_entry="$(getent group "${g}")"; then
+      core::log error "system group missing after creation" "$(printf '{"group":"%s","hint":"verify group database state"}' "${g}")"
+      return 1
+    fi
+  else
+    core::log debug "system group already exists" "$(printf '{"group":"%s"}' "${g}")"
+  fi
+
+  IFS=':' read -r _ _ expected_gid _ <<< "${group_entry}"
+  if [[ -z "${expected_gid}" ]]; then
+    core::log error "could not determine system group gid" "$(printf '{"group":"%s"}' "${g}")"
+    return 1
+  fi
+
+  if user_entry="$(getent passwd "${u}")"; then
+    IFS=':' read -r _ _ _ user_gid _ <<< "${user_entry}"
+    if [[ "${user_gid}" != "${expected_gid}" ]]; then
+      core::log error "system user has unexpected primary group" "$(printf '{"user":"%s","expected_group":"%s","expected_gid":"%s","actual_gid":"%s","hint":"recreate user with --gid %s or update existing assignment"}' "${u}" "${g}" "${expected_gid}" "${user_gid:-}" "${g}")"
+      return 1
+    fi
+    core::log debug "system user already exists" "$(printf '{"user":"%s","group":"%s"}' "${u}" "${g}")"
+    return 0
+  fi
+
+  core::log info "creating system user" "$(printf '{"user":"%s","group":"%s"}' "${u}" "${g}")"
+  if ! sudo useradd --system --gid "${g}" --home-dir "/var/lib/${u}" --no-create-home --shell /usr/sbin/nologin "${u}"; then
+    core::log error "failed to create system user" "$(printf '{"user":"%s","group":"%s","hint":"create user manually with system flags and expected group"}' "${u}" "${g}")"
+    return 1
+  fi
+
+  if ! getent passwd "${u}" > /dev/null 2>&1; then
+    core::log error "system user missing after creation" "$(printf '{"user":"%s","hint":"verify passwd database state"}' "${u}")"
+    return 1
+  fi
+
+  core::log info "system user ensured" "$(printf '{"user":"%s","group":"%s"}' "${u}" "${g}")"
+  return 0
 }

--- a/tests/unit/test_user.bats
+++ b/tests/unit/test_user.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2154  # Variables defined in test_helper.bash
+
+load ../test_helper
+
+setup() {
+  setup_test_env
+  create_user_mocks
+  source "${PROJECT_ROOT}/modules/user/user.sh"
+}
+
+teardown() {
+  cleanup_test_env
+}
+
+create_user_mocks() {
+  mkdir -p "${TEST_TMPDIR}/bin"
+
+  cat > "${TEST_TMPDIR}/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+"$@"
+EOF
+
+  cat > "${TEST_TMPDIR}/bin/getent" <<'EOF'
+#!/usr/bin/env bash
+record="${TEST_TMPDIR}/${1}_${2}"
+if [[ -f "${record}" ]]; then
+  cat "${record}"
+  exit 0
+fi
+exit 2
+EOF
+
+  cat > "${TEST_TMPDIR}/bin/groupadd" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${TEST_TMPDIR}/groupadd_calls"
+if [[ "${MOCK_GROUPADD_FAIL:-0}" == "1" ]]; then
+  exit 1
+fi
+group="${@: -1}"
+gid="${MOCK_GROUP_GID:-998}"
+printf "%s:x:%s:\n" "${group}" "${gid}" > "${TEST_TMPDIR}/group_${group}"
+EOF
+
+  cat > "${TEST_TMPDIR}/bin/useradd" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${TEST_TMPDIR}/useradd_calls"
+if [[ "${MOCK_USERADD_FAIL:-0}" == "1" ]]; then
+  exit 1
+fi
+
+group=""
+prev=""
+for arg in "$@"; do
+  if [[ "${prev}" == "--gid" ]]; then
+    group="${arg}"
+  fi
+  prev="${arg}"
+done
+
+user="${@: -1}"
+gid="${MOCK_GROUP_GID:-998}"
+if [[ -n "${group}" && -f "${TEST_TMPDIR}/group_${group}" ]]; then
+  IFS=':' read -r _ _ gid _ < "${TEST_TMPDIR}/group_${group}"
+fi
+
+printf "%s:x:1000:%s::/var/lib/%s:/usr/sbin/nologin\n" "${user}" "${gid}" "${user}" > "${TEST_TMPDIR}/passwd_${user}"
+EOF
+
+  chmod +x "${TEST_TMPDIR}/bin/"{sudo,getent,groupadd,useradd}
+}
+
+mock_path() {
+  echo "${TEST_TMPDIR}/bin:${PATH}"
+}
+
+@test "creates system user and group when missing" {
+  rm -f "${TEST_TMPDIR}/group_demo" "${TEST_TMPDIR}/passwd_demo"
+  PATH="$(mock_path)" run user::ensure_system_user demo demo
+  [ "${status}" -eq 0 ]
+  assert_file_exists "${TEST_TMPDIR}/group_demo"
+  assert_file_exists "${TEST_TMPDIR}/passwd_demo"
+  assert_file_exists "${TEST_TMPDIR}/useradd_calls"
+  assert_file_exists "${TEST_TMPDIR}/groupadd_calls"
+}
+
+@test "fails when group creation fails" {
+  PATH="$(mock_path)" MOCK_GROUPADD_FAIL=1 run user::ensure_system_user demo demo
+  [ "${status}" -ne 0 ]
+  [ ! -f "${TEST_TMPDIR}/group_demo" ]
+  [ ! -f "${TEST_TMPDIR}/passwd_demo" ]
+}
+
+@test "fails when user creation fails" {
+  PATH="$(mock_path)" MOCK_USERADD_FAIL=1 run user::ensure_system_user demo demo
+  [ "${status}" -ne 0 ]
+  assert_file_exists "${TEST_TMPDIR}/group_demo"
+  [ ! -f "${TEST_TMPDIR}/passwd_demo" ]
+}
+
+@test "fails when existing user has different primary group" {
+  printf "demo:x:2000:\n" > "${TEST_TMPDIR}/group_demo"
+  printf "demo:x:1000:999::/home/demo:/bin/bash\n" > "${TEST_TMPDIR}/passwd_demo"
+
+  PATH="$(mock_path)" run user::ensure_system_user demo demo
+  [ "${status}" -ne 0 ]
+  [ ! -f "${TEST_TMPDIR}/useradd_calls" ]
+}
+
+@test "succeeds when user already matches expected group" {
+  printf "demo:x:2000:\n" > "${TEST_TMPDIR}/group_demo"
+  printf "demo:x:1000:2000::/home/demo:/bin/bash\n" > "${TEST_TMPDIR}/passwd_demo"
+
+  PATH="$(mock_path)" run user::ensure_system_user demo demo
+  [ "${status}" -eq 0 ]
+  [ ! -f "${TEST_TMPDIR}/useradd_calls" ]
+}


### PR DESCRIPTION
## Summary
- add a source guard and structured logging to the user module while propagating failures
- validate existing user/group associations and raise actionable errors on mismatches or creation issues
- add bats coverage mocking getent/groupadd/useradd for success and failure paths

## Testing
- make fmt *(fails: shfmt not installed)*
- make lint *(fails: shellcheck not installed)*
- make test-unit *(fails: bats not installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953db406a2883249c8d24346e03fad5)