### PR TITLE
Harden systemd unit installation

### DIFF
--- a/services/xray/systemd-unit.sh
+++ b/services/xray/systemd-unit.sh
@@ -5,24 +5,63 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 . "${HERE}/modules/io.sh"
 . "${HERE}/modules/user/user.sh"
 . "${HERE}/lib/plugins.sh"
-unit_path() { echo "/etc/systemd/system/xray.service"; }
+. "${HERE}/modules/state.sh"
+unit_path() { systemd_unit_path; }
 install_unit() {
   core::init "${@}"
+  core::log info "installing systemd unit" "{}"
+  core::with_flock "$(state::lock)" install_unit_with_lock
+}
+systemd_unit_path() {
+  local base="${XRF_SYSTEMD_DIR:-/etc/systemd/system}"
+  echo "${base%/}/xray.service"
+}
+install_unit_with_lock() {
   user::ensure_system_user xray xray
   local unit_file
-  unit_file="$(unit_path)"
-  io::atomic_write "${unit_file}" 0644 < "${HERE}/packaging/systemd/xray.service"
-  systemctl daemon-reload
-  systemctl enable --now xray || true
+  unit_file="$(systemd_unit_path)"
+  core::log info "preparing systemd unit directory" "$(printf '{"dir":"%s"}' "$(dirname "${unit_file}")")"
+  io::ensure_dir "$(dirname "${unit_file}")" 0755
+  core::log info "writing systemd unit file" "$(printf '{"path":"%s"}' "${unit_file}")"
+  if ! io::atomic_write "${unit_file}" 0644 < "${HERE}/packaging/systemd/xray.service"; then
+    core::log error "failed to write systemd unit" "$(printf '{"path":"%s"}' "${unit_file}")"
+    return 1
+  fi
+  core::log info "reloading systemd manager configuration" '{}'
+  if ! systemctl daemon-reload; then
+    core::log error "systemctl daemon-reload failed" '{}'
+    rm -f "${unit_file}" 2> /dev/null || true
+    return 1
+  fi
+  core::log info "enabling and starting xray service" "$(printf '{"unit":"%s"}' "xray.service")"
+  if ! systemctl enable --now xray; then
+    core::log error "systemctl enable --now failed" "$(printf '{"unit":"%s"}' "xray.service")"
+    rollback_systemd_unit "${unit_file}"
+    return 1
+  fi
   plugins::ensure_dirs
   plugins::load_enabled
   plugins::emit service_setup "unit=${unit_file}"
   core::log info "systemd unit installed" "$(printf '{"path":"%s"}' "${unit_file}")"
 }
+rollback_systemd_unit() {
+  local unit_file="${1}"
+  core::log warn "rolling back systemd unit installation" "$(printf '{"path":"%s"}' "${unit_file}")"
+  if ! systemctl disable --now xray; then
+    core::log warn "systemctl disable during rollback failed" "$(printf '{"unit":"%s"}' "xray.service")"
+  fi
+  rm -f "${unit_file}" 2> /dev/null || true
+  if ! systemctl daemon-reload; then
+    core::log warn "systemctl daemon-reload during rollback failed" '{}'
+  fi
+  if ! systemctl reset-failed xray.service 2> /dev/null; then
+    core::log warn "systemctl reset-failed during rollback failed" '{}'
+  fi
+}
 remove_unit() {
   core::init "${@}"
   local unit_file
-  unit_file="$(unit_path)"
+  unit_file="$(systemd_unit_path)"
   plugins::ensure_dirs
   plugins::load_enabled
   plugins::emit service_remove "unit=${unit_file}"

--- a/tests/integration/test_helper.bash
+++ b/tests/integration/test_helper.bash
@@ -3,6 +3,7 @@
 
 # Setup isolated test environment
 setup_integration_env() {
+  export PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   export TEST_ROOT="${BATS_TEST_TMPDIR}/xrf-integration"
   export XRF_PREFIX="${TEST_ROOT}/prefix"
   export XRF_ETC="${TEST_ROOT}/etc"

--- a/tests/integration/test_systemd_unit.bats
+++ b/tests/integration/test_systemd_unit.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# Integration-style tests for systemd unit installation handling
+
+load test_helper
+
+setup() {
+  setup_integration_env
+  mkdir -p "${XRF_ETC}/systemd/system" "${XRF_VAR}"
+
+  cat > "${TEST_ROOT}/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+echo "systemctl $*" >> "${XRF_VAR}/systemctl.log"
+case "${1:-}" in
+  daemon-reload) exit 0 ;;
+  enable) exit 1 ;; # simulate start failure
+  disable) exit 0 ;;
+  reset-failed) exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "${TEST_ROOT}/bin/systemctl"
+
+  cat > "${TEST_ROOT}/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+echo "sudo $*" >> "${XRF_VAR}/sudo.log"
+exit 0
+EOF
+  chmod +x "${TEST_ROOT}/bin/sudo"
+
+  cat > "${TEST_ROOT}/bin/getent" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "${TEST_ROOT}/bin/getent"
+}
+
+teardown() {
+  cleanup_integration_env
+}
+
+@test "install_unit rolls back when systemctl enable fails" {
+  export XRF_SYSTEMD_DIR="${XRF_ETC}/systemd/system"
+
+  run "${PROJECT_ROOT}/services/xray/systemd-unit.sh" install
+
+  [ "$status" -ne 0 ]
+  [ ! -f "${XRF_SYSTEMD_DIR}/xray.service" ]
+  [ -f "${XRF_VAR}/systemctl.log" ]
+  reload_count="$(grep -c 'systemctl daemon-reload' "${XRF_VAR}/systemctl.log")"
+  [ "${reload_count}" -ge 2 ]
+  grep -q "systemctl enable --now xray" "${XRF_VAR}/systemctl.log"
+  grep -q "systemctl disable --now xray" "${XRF_VAR}/systemctl.log"
+  grep -q "systemctl reset-failed xray.service" "${XRF_VAR}/systemctl.log"
+}


### PR DESCRIPTION
## Summary
- add structured logging and locking around systemd unit installation with explicit path support
- rollback enablement by disabling, removing the unit file, and resetting failures when systemctl start fails
- add integration-style bats test to mock systemctl failures and assert rollback behavior

## Testing
- make fmt *(fails: shfmt not available in environment)*
- make lint *(fails: shellcheck not available in environment)*
- make test-unit *(fails: bats not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953db45c9b48324b33b7136868229a2)