### PR TITLE
Add source guards and idempotent module sourcing tests

### DIFF
--- a/modules/io.sh
+++ b/modules/io.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 # Atomic write + safe install helpers
+# NOTE: This module is sourced; strict mode (set -euo pipefail) must be enabled by the caller (e.g., via core::init()).
+
+[[ -n "${_XRF_IO_LOADED:-}" ]] && return 0
+readonly _XRF_IO_LOADED=1
+
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=lib/core.sh
 . "${HERE}/lib/core.sh"

--- a/modules/net/network.sh
+++ b/modules/net/network.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 # Network helpers
+# NOTE: This module is sourced; callers are responsible for enabling strict mode (set -euo pipefail) via core::init().
+
+[[ -n "${_XRF_NET_NETWORK_LOADED:-}" ]] && return 0
+readonly _XRF_NET_NETWORK_LOADED=1
 
 net::detect_public_ip() {
   local ip=""

--- a/modules/state.sh
+++ b/modules/state.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # State management module
-# NOTE: This file is sourced. Strict mode is set by core::init() from the calling script
+# NOTE: This module is sourced; strict mode (set -euo pipefail) is expected to be enabled by the caller via core::init().
+
+[[ -n "${_XRF_STATE_LOADED:-}" ]] && return 0
+readonly _XRF_STATE_LOADED=1
+
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=modules/io.sh
 . "${HERE}/modules/io.sh"
 
 state::dir() { echo "${XRF_VAR:-/var/lib/xray-fusion}"; }

--- a/tests/unit/test_module_sourcing.bats
+++ b/tests/unit/test_module_sourcing.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+# Verify modules can be sourced multiple times (idempotent guards)
+
+load '../test_helper'
+
+setup() {
+  setup_test_env
+}
+
+teardown() {
+  cleanup_test_env
+}
+
+@test "modules/io.sh is idempotent when sourced multiple times" {
+  run bash -c 'source "${PROJECT_ROOT}/modules/io.sh"; source "${PROJECT_ROOT}/modules/io.sh"; io::writable "/tmp" >/dev/null'
+  [ "$status" -eq 0 ]
+}
+
+@test "modules/state.sh is idempotent when sourced multiple times" {
+  run bash -c 'source "${PROJECT_ROOT}/modules/state.sh"; source "${PROJECT_ROOT}/modules/state.sh"; state::path >/dev/null'
+  [ "$status" -eq 0 ]
+}
+
+@test "modules/net/network.sh is idempotent when sourced multiple times" {
+  run bash -c 'source "${PROJECT_ROOT}/modules/net/network.sh"; source "${PROJECT_ROOT}/modules/net/network.sh"; type net::detect_public_ip >/dev/null'
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- add module source guards and strict-mode documentation to io, state, and network helpers
- ensure module dependencies are sourced after guards to maintain idempotent sourcing
- add a bats test covering repeated sourcing for the guarded modules

## Testing
- make fmt *(fails: shfmt not found in environment)*
- make lint *(fails: shellcheck not found in environment)*
- make test-unit *(fails: bats not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953db41a9d08324837aaf255aa98ef2)