### PR TITLE
docs: Add ADR-012 for Xray v26.1.23 compatibility review

### DIFF
--- a/docs/adr/012-xray-v26-review.md
+++ b/docs/adr/012-xray-v26-review.md
@@ -1,0 +1,74 @@
+# ADR-012: Xray v26.1.23 Updates Review
+
+**Date**: 2026-01-24
+**Status**: Accepted
+
+## Problem
+
+Xray-core released v26.1.23 (2026-01-23) with significant new features and deprecation warnings requiring evaluation for project compatibility.
+
+## Decision
+
+Maintain current configuration; no changes required to core implementation.
+
+## Analysis
+
+### 1. Deprecation Warnings (v26.x)
+
+**VLESS without flow** - Critical deprecation warning added.
+
+**Project Status**: Already compliant. All VLESS configurations include `flow: "xtls-rprx-vision"`:
+- `configure.sh:240` - Reality-only inbound
+- `configure.sh:332` - Vision inbound
+- `configure.sh:358` - Reality inbound (dual topology)
+
+**Other deprecations** (not applicable):
+- `allowInsecure` - Not used
+- Shadowsocks/VMess/Trojan protocols - Not used
+
+### 2. TUN Inbound Support (v26.1.23)
+**Not applicable**
+- Client-side feature for Windows/Linux/Android/macOS
+- Server deployments do not require TUN inbound
+- Requires manual system route configuration
+
+### 3. Process-Based Routing (v26.1.23)
+**Not applicable**
+- Client-side routing feature
+- Matches process name/path for traffic filtering
+- Not relevant for server configurations
+
+### 4. Hysteria 2 Protocol (v26.1.23)
+**Document for future reference**
+- New UDP-based protocol with port hopping
+- Salamander obfuscation layer available
+- Current REALITY/Vision stack sufficient for most use cases
+
+### 5. TLS Certificate Pinning Changes (v26.x)
+**Not applicable**
+- `pinnedPeerCertSha256` replaces previous dual parameters
+- Client-side TLS configuration only
+- Server certificates unaffected
+
+### 6. REALITY Client Improvements (v26.x)
+**Document only**
+- Enhanced MITM detection warnings in client logs
+- No server-side configuration changes required
+
+## Rationale
+
+- All VLESS configurations already include required `flow` parameter
+- Project uses recommended REALITY + Vision stack
+- TLS 1.3 enforcement (`minVersion: "1.3"`) exceeds baseline security
+- Dynamic version fetching (`version="latest"`) automatically uses v26.1.23
+
+## Impact
+
+- Zero breaking changes required
+- Full compatibility with Xray-core v26.1.23 confirmed
+- No configuration updates needed
+
+## References
+
+- Xray-core v26.1.23 Release: https://github.com/XTLS/Xray-core/releases/tag/v26.1.23
+- Previous Review: [ADR-011](./011-xray-v25-review.md) (v25.12.8)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,6 +17,7 @@ This directory contains Architecture Decision Records for the xray-fusion projec
 | [009](./009-bats-testing-framework.md) | Automated Testing with bats-core | 2025-11-09 | Accepted |
 | [010](./010-phase1-security-enhancements.md) | Phase 1 Security Enhancements | 2025-11-10 | Accepted |
 | [011](./011-xray-v25-review.md) | Xray v25.12.8 Updates Review | 2025-12-09 | Accepted |
+| [012](./012-xray-v26-review.md) | Xray v26.1.23 Updates Review | 2026-01-24 | Accepted |
 
 ## ADR Format
 


### PR DESCRIPTION
## Summary
This PR adds Architecture Decision Record 012 documenting the review and compatibility assessment of Xray-core v26.1.23 released on 2026-01-23.

## Changes
- **New ADR Document**: `docs/adr/012-xray-v26-review.md`
  - Comprehensive analysis of v26.1.23 features and deprecations
  - Confirms full compatibility with current project configuration
  - Documents that no breaking changes or configuration updates are required
  
- **Updated ADR Index**: `docs/adr/README.md`
  - Added entry for ADR-012 to the decision records table

## Key Findings
The review confirms:
- ✅ All VLESS configurations already include required `flow: "xtls-rprx-vision"` parameter (compliant with deprecation warnings)
- ✅ Project uses recommended REALITY + Vision stack
- ✅ TLS 1.3 enforcement exceeds baseline security requirements
- ✅ Zero breaking changes required for v26.1.23 adoption
- ℹ️ Documented new features (TUN inbound, process-based routing, Hysteria 2) for future reference

## Impact
- Full compatibility with Xray-core v26.1.23 confirmed
- No configuration changes needed
- Dynamic version fetching automatically uses latest release