### PR TITLE
Remove unnecessary variable unset statements

### DIFF
--- a/commands/install.sh
+++ b/commands/install.sh
@@ -247,12 +247,10 @@ main() {
     fi
     XRAY_PRIVATE_KEY="${private_key}"
     XRAY_PUBLIC_KEY="${public_key}"
-    unset keypair private_key public_key
   elif [[ -n "${XRAY_PRIVATE_KEY:-}" && -z "${XRAY_PUBLIC_KEY:-}" && -x "$(xray::bin)" ]]; then
     local derived_public
     if derived_public="$(x25519::derive_public_key "$(xray::bin)" "${XRAY_PRIVATE_KEY}")"; then
       XRAY_PUBLIC_KEY="${derived_public}"
-      unset derived_public
     else
       core::log error "failed to derive public key from provided private key" '{"suggestion":"re-run: xray x25519"}'
       exit 1


### PR DESCRIPTION
## Summary
Removed two `unset` statements that are unnecessary for local variables in bash functions, improving code cleanliness without affecting functionality.

## Key Changes
- Removed `unset keypair private_key public_key` after assigning values to `XRAY_PRIVATE_KEY` and `XRAY_PUBLIC_KEY`
- Removed `unset derived_public` after assigning the derived public key to `XRAY_PUBLIC_KEY`

## Implementation Details
Local variables in bash functions are automatically scoped and cleaned up when the function exits. Explicitly unsetting them provides no practical benefit and adds unnecessary lines. The variables in question (`keypair`, `private_key`, `public_key`, and `derived_public`) are only used within their respective code blocks and don't need manual cleanup.