### PR TITLE
Refactor: Improve readability of argument parsing in main()

### DIFF
--- a/services/xray/configure.sh
+++ b/services/xray/configure.sh
@@ -505,11 +505,15 @@ deploy_with_lock() {
 main() {
   core::init "${@}"
   local topology="reality-only"
-  while [[ $# -gt 0 ]]; do case "${1}" in --topology)
-    topology="${2}"
-    shift 2
-    ;;
-  *) shift ;; esac done
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      --topology)
+        topology="${2}"
+        shift 2
+        ;;
+      *) shift ;;
+    esac
+  done
 
   # Security: Validate topology parameter
   case "${topology}" in


### PR DESCRIPTION
## Summary
Reformatted the argument parsing logic in the `main()` function to improve code readability and maintainability by applying consistent indentation and spacing conventions.

## Changes
- Expanded the compact while-case loop into a more readable multi-line format
- Applied proper indentation to the case statement and its branches
- Improved visual hierarchy to make the control flow easier to follow
- No functional changes to the logic or behavior

## Details
The argument parsing loop that handles the `--topology` parameter was previously written in a compact single-line style. This refactoring expands it to follow standard shell script formatting conventions, making it easier to read, maintain, and extend in the future. The logic remains identical—only the formatting has changed.