### PR TITLE
lib: clarify shared helpers

### DIFF
--- a/lib/args.sh
+++ b/lib/args.sh
@@ -142,7 +142,10 @@ args::validate_topology() {
 # Domain validation
 args::validate_domain() {
   local domain="${1:-}"
-  [[ -z "${domain}" ]] && return 0 # Domain is optional for reality-only
+
+  if [[ -z "${domain}" ]]; then
+    return 0 # Domain is optional for reality-only
+  fi
 
   # Use shared validator (RFC compliant, length limits, internal domain check)
   # Validator logs specific rejection reason via debug output

--- a/lib/error_codes.sh
+++ b/lib/error_codes.sh
@@ -110,7 +110,9 @@ error_codes::invalid_domain() {
   local specific_reason="${2:-}"
 
   local reason="Domain '${domain}' is invalid"
-  [[ -n "${specific_reason}" ]] && reason="${reason}: ${specific_reason}"
+  if [[ -n "${specific_reason}" ]]; then
+    reason="${reason}: ${specific_reason}"
+  fi
 
   local resolution="Use a public domain name for vision-reality topology, or switch to reality-only topology which doesn't require a domain."
 
@@ -159,7 +161,9 @@ error_codes::missing_parameter() {
   local context="${2:-}"
 
   local reason="Required parameter '--${param}' is missing"
-  [[ -n "${context}" ]] && reason="${reason} for ${context}"
+  if [[ -n "${context}" ]]; then
+    reason="${reason} for ${context}"
+  fi
 
   local resolution="Provide the --${param} parameter or choose a different configuration"
 
@@ -195,7 +199,9 @@ error_codes::port_conflict() {
   local process="${2:-unknown}"
 
   local reason="Port ${port} is already in use"
-  [[ "${process}" != "unknown" ]] && reason="${reason} by ${process}"
+  if [[ "${process}" != "unknown" ]]; then
+    reason="${reason} by ${process}"
+  fi
 
   local resolution="Stop the conflicting service or use a different port"
 

--- a/modules/io.sh
+++ b/modules/io.sh
@@ -28,15 +28,19 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 #   io::ensure_dir "/etc/app" "0750"        # Create with 0750
 ##
 io::ensure_dir() {
-  local dir="${1}" mode="${2:-0755}"
-  [[ -d "${dir}" ]] && {
+  local dir="${1}"
+  local mode="${2:-0755}"
+
+  if [[ -d "${dir}" ]]; then
     chmod "${mode}" "${dir}" || true
     return 0
-  }
-  mkdir -p "${dir}" 2> /dev/null || {
+  fi
+
+  if ! mkdir -p "${dir}" 2> /dev/null; then
     core::log warn "mkdir fallback sudo" "$(printf '{"dir":"%s"}' "${dir}")"
     sudo mkdir -p "${dir}"
-  }
+  fi
+
   chmod "${mode}" "${dir}" || true
 }
 
@@ -85,7 +89,8 @@ io::writable() { test -w "${1}" 2> /dev/null; }
 #   cat file.txt | io::atomic_write "/var/lib/app/data"
 ##
 io::atomic_write() {
-  local dst="${1}" mode="${2:-0644}"
+  local dst="${1}"
+  local mode="${2:-0644}"
   local dstdir tmp
   dstdir="$(dirname "${dst}")"
 

--- a/modules/state.sh
+++ b/modules/state.sh
@@ -9,10 +9,21 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=modules/io.sh
 . "${HERE}/modules/io.sh"
 
-state::dir() { echo "${XRF_VAR:-/var/lib/xray-fusion}"; }
-state::path() { echo "$(state::dir)/state.json"; }
-state::digest() { echo "$(state::dir)/config.sha256"; }
-state::lock() { echo "$(state::dir)/locks/configure.lock"; }
+state::dir() {
+  printf '%s\n' "${XRF_VAR:-/var/lib/xray-fusion}"
+}
+
+state::path() {
+  printf '%s\n' "$(state::dir)/state.json"
+}
+
+state::digest() {
+  printf '%s\n' "$(state::dir)/config.sha256"
+}
+
+state::lock() {
+  printf '%s\n' "$(state::dir)/locks/configure.lock"
+}
 
 state::save() {
   local j="${1}"


### PR DESCRIPTION
### Motivation
- Improve clarity and consistency in core helpers to make intent and control flow easier to read and maintain.
- Apply small, behavior-preserving refactors that follow project shell patterns and avoid dense one-liners.
- Reduce conditional/inline complexity in commonly used utilities to lower cognitive overhead for future changes.

### Description
- `modules/io.sh`: split local variable declarations and replaced compact inline conditions in `io::ensure_dir` with an explicit `if`/`then` flow, and made `io::atomic_write` locals explicit to improve readability while preserving behavior.
- `modules/state.sh`: expanded short one-liner helpers into small functions using `printf` (`state::dir`, `state::path`, `state::digest`, `state::lock`) to make outputs and intent explicit without changing return values.
- `lib/args.sh`: made domain validation return path use an explicit `if [[ -z ... ]]` block instead of an inline guard for clearer control flow.
- `lib/error_codes.sh`: replaced several inline conditional expressions with explicit `if` checks when composing error messages to improve readability and consistency.

### Testing
- Ran `make fmt` which failed due to missing `shfmt` (tool not installed), so formatting step could not be validated.
- Ran `make lint` which failed due to missing `shellcheck` (tool not installed), so linting could not be validated.
- Ran `make test-unit` which failed due to missing `bats` (tool not installed), so unit tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6975de9a13e48333831414f398c3c03a)