### PR TITLE
Update hook formats and improve session initialization

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -147,7 +147,7 @@ A  tests/unit/test_new.bats
   # OR stash changes:
   git stash push -m 'WIP: description'
 
-{"approved": false, "reason": "Uncommitted changes detected - commit or stash before stopping"}
+{"decision": "block", "reason": "Uncommitted changes detected - commit or stash before stopping"}
 ```
 
 **Example Output** (warning scenario):
@@ -164,7 +164,7 @@ A  tests/unit/test_new.bats
   - .claude/README.md: Document new hooks or commands
 
 [Stop] ✓ Git status clean, safe to end session
-{"approved": true}
+{"decision": "allow"}
 ```
 
 **Security Benefits**:
@@ -332,8 +332,8 @@ if [ -f file ];then
 echo "test"
 fi' > /tmp/test.sh
 
-# Test hook
-echo '{"params":{"file_path":"/tmp/test.sh"}}' | \
+# Test hook (official PostToolUse stdin format)
+echo '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/test.sh"}}' | \
   .claude/scripts/format-and-lint-shell.sh
 
 # Expected: File formatted and linted

--- a/.claude/scripts/session-start.sh
+++ b/.claude/scripts/session-start.sh
@@ -39,6 +39,12 @@ echo "[SessionStart] Web/iOS environment detected, auto-installing development t
 mkdir -p "${HOME}/.local/bin" "${HOME}/.local/share"
 export PATH="${HOME}/.local/bin:${PATH}"
 
+# Persist PATH for subsequent commands via CLAUDE_ENV_FILE
+if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+  echo "export PATH=\"\${HOME}/.local/bin:\${PATH}\"" >> "${CLAUDE_ENV_FILE}"
+  echo "[SessionStart] PATH persisted to CLAUDE_ENV_FILE" >&2
+fi
+
 # Helper function to install tool
 install_tool() {
   local name="${1}"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/session-start.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/session-start.sh",
+            "timeout": 120
           }
         ]
       }


### PR DESCRIPTION
## Summary
This PR updates the Claude hook system to use standardized formats and improves session initialization with environment persistence.

## Key Changes

- **Hook Response Format**: Updated `session-stop.sh` documentation examples to use the new standardized response format:
  - Changed `{"approved": false}` to `{"decision": "block"}`
  - Changed `{"approved": true}` to `{"decision": "allow"}`
  - This aligns with the official decision-based response schema

- **PostToolUse Hook Input Format**: Updated `format-and-lint-shell.sh` test example to use the official stdin format:
  - Changed from `{"params":{"file_path":"..."}}` 
  - To `{"tool_name":"Edit","tool_input":{"file_path":"..."}}`
  - Added clarifying comment about the official PostToolUse format

- **Session Start Environment Persistence**: Enhanced `session-start.sh` to persist PATH modifications:
  - Added logic to write PATH export to `CLAUDE_ENV_FILE` when available
  - Ensures PATH changes (e.g., `~/.local/bin`) persist across subsequent commands in the session
  - Includes debug logging for troubleshooting

- **Session Start Timeout**: Added 120-second timeout to the session-start hook in `settings.json`:
  - Prevents hanging if tool installation takes too long
  - Ensures predictable session initialization behavior

## Implementation Details
The environment persistence uses the `CLAUDE_ENV_FILE` mechanism to ensure that PATH modifications made during session initialization are available to all subsequent commands, improving reliability of tool availability throughout the session.