### PR TITLE
[codex] Default Reality SNI to Apple

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -352,7 +352,7 @@ sudo ufw allow 443/tcp
 systemctl status xray
 
 # Check server_name matches client configuration
-# Client SNI must match XRAY_SNI value (default: www.microsoft.com)
+# Client SNI must match XRAY_SNI value (default: www.apple.com)
 ```
 
 **Related**: Reality protocol configuration

--- a/commands/install.sh
+++ b/commands/install.sh
@@ -28,7 +28,7 @@ EOF
 Xray Configuration Variables:
   XRAY_SNIFFING=false|true
   # reality-only
-  XRAY_PORT=443 XRAY_UUID=<uuid> XRAY_SNI=www.microsoft.com[,alt] XRAY_REALITY_DEST=www.microsoft.com XRAY_PRIVATE_KEY=<X25519> XRAY_SHORT_ID=<hex>
+  XRAY_PORT=443 XRAY_UUID=<uuid> XRAY_SNI=www.apple.com[,alt] XRAY_REALITY_DEST=www.apple.com XRAY_PRIVATE_KEY=<X25519> XRAY_SHORT_ID=<hex>
   # vision-reality
   XRAY_VISION_PORT=8443 XRAY_REALITY_PORT=443 XRAY_FALLBACK_PORT=8080 XRAY_UUID_VISION=<uuid> XRAY_UUID_REALITY=<uuid> XRAY_CERT_DIR=/usr/local/etc/xray/certs XRAY_PRIVATE_KEY=<X25519> XRAY_SHORT_ID=<hex>
   # Optional VLESS Encryption (advanced)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -37,7 +37,7 @@ curl -sL install.sh | bash -s -- --template office --domain vpn.company.com
 
 ### Reality-only
 - No domain required
-- SNI camouflage (default: `www.microsoft.com`)
+- SNI camouflage (default: `www.apple.com`)
 - Port: 443
 - Supports optional VLESS Encryption (`decryption` configurable)
 - Auto network profile: IPv4-only hosts use `listen: 0.0.0.0` + `dns.queryStrategy: UseIPv4`
@@ -91,7 +91,7 @@ xrf export all --out-dir /tmp/xrf-export
 ## Environment Variables
 
 ```bash
-XRAY_SNI=www.microsoft.com                    # Reality SNI
+XRAY_SNI=www.apple.com                        # Reality SNI
 XRAY_VISION_PORT=8443                         # Vision port
 XRAY_REALITY_PORT=443                         # Reality port
 XRAY_VLESS_ENCRYPTION_ENABLED=false           # Optional VLESS Encryption switch

--- a/install.sh
+++ b/install.sh
@@ -454,7 +454,7 @@ Environment Variables:
   XRF_INSTALL_DIR   Installation directory (default: /usr/local/xray-fusion)
 
 Xray Configuration Variables:
-  XRAY_SNI          SNI domain (default: www.microsoft.com)
+  XRAY_SNI          SNI domain (default: www.apple.com)
   XRAY_PORT         Listen port (default: 443)
   XRAY_UUID         User UUID (auto-generated if not set)
   XRAY_*            All other Xray configuration variables

--- a/lib/defaults.sh
+++ b/lib/defaults.sh
@@ -23,7 +23,7 @@ readonly DEFAULT_CADDY_CERT_BASE="/root/.local/share/caddy/certificates"
 readonly DEFAULT_XRAY_CERT_DIR="/usr/local/etc/xray/certs"
 
 # === Reality Protocol Defaults ===
-readonly DEFAULT_XRAY_SNI="www.microsoft.com"
+readonly DEFAULT_XRAY_SNI="www.apple.com"
 readonly DEFAULT_XRAY_SNIFFING="true"
 readonly DEFAULT_XRAY_FINGERPRINT="chrome"
 readonly DEFAULT_XRAY_VLESS_ENCRYPTION_ENABLED="false"

--- a/lib/export.sh
+++ b/lib/export.sh
@@ -27,7 +27,7 @@ export::load_context() {
     echo "${state}" | jq -r '
       [
         .name // .topology // "reality-only",
-        .xray.reality_sni // "www.microsoft.com",
+        .xray.reality_sni // "www.apple.com",
         .xray.short_id // "",
         .xray.reality_public_key // "",
         .xray.vision_port // "8443",
@@ -44,7 +44,7 @@ export::load_context() {
   )
 
   EX_TOPO="${fields[0]:-reality-only}"
-  EX_SNI="${fields[1]:-www.microsoft.com}"
+  EX_SNI="${fields[1]:-www.apple.com}"
   EX_SID="${fields[2]:-}"
   EX_PBK="${fields[3]:-}"
   EX_VPORT="${fields[4]:-8443}"

--- a/services/xray/client-links.sh
+++ b/services/xray/client-links.sh
@@ -21,7 +21,7 @@ main() {
     echo "${state}" | jq -r '
       [
         .name // .topology // "reality-only",
-        .xray.reality_sni // "www.microsoft.com",
+        .xray.reality_sni // "www.apple.com",
         .xray.short_id // "",
         .xray.reality_public_key // "",
         .xray.vision_port // "8443",

--- a/services/xray/configure.sh
+++ b/services/xray/configure.sh
@@ -249,7 +249,7 @@ xray::render_reality_inbound() {
   local vless_decryption="${XRAY_VLESS_DECRYPTION:-none}"
 
   # Validate required variables
-  : "${XRAY_PORT:=443}" : "${XRAY_UUID:?}" : "${XRAY_SNI:=www.microsoft.com}"
+  : "${XRAY_PORT:=443}" : "${XRAY_UUID:?}" : "${XRAY_SNI:=www.apple.com}"
   : "${XRAY_SHORT_ID:?}" : "${XRAY_PRIVATE_KEY:?}"
 
   validators::port "${XRAY_PORT}" || core::log fatal "invalid XRAY_PORT" "$(printf '{"port":"%s"}' "${XRAY_PORT}")"
@@ -327,7 +327,7 @@ xray::render_vision_reality_inbounds() {
   : "${XRAY_VISION_PORT:=8443}" : "${XRAY_REALITY_PORT:=443}"
   : "${XRAY_UUID_VISION:?}" : "${XRAY_UUID_REALITY:?}" : "${XRAY_DOMAIN:?}"
   : "${XRAY_CERT_DIR:=/usr/local/etc/xray/certs}" : "${XRAY_FALLBACK_PORT:=8080}"
-  : "${XRAY_SNI:=www.microsoft.com}" : "${XRAY_SHORT_ID:?}" : "${XRAY_PRIVATE_KEY:?}"
+  : "${XRAY_SNI:=www.apple.com}" : "${XRAY_SHORT_ID:?}" : "${XRAY_PRIVATE_KEY:?}"
 
   core::log debug "vision-reality variables set" "$(printf '{"vision_port":"%s","reality_port":"%s","domain":"%s"}' \
     "${XRAY_VISION_PORT}" "${XRAY_REALITY_PORT}" "${XRAY_DOMAIN}")"

--- a/templates/built-in/home.json
+++ b/templates/built-in/home.json
@@ -13,8 +13,8 @@
     "xray": {
       "version": "latest",
       "port": 443,
-      "sni": "www.microsoft.com",
-      "reality_dest": "www.microsoft.com:443",
+      "sni": "www.apple.com",
+      "reality_dest": "www.apple.com:443",
       "sniffing": false
     },
     "plugins": [],

--- a/tests/unit/test_client_links.bats
+++ b/tests/unit/test_client_links.bats
@@ -299,8 +299,8 @@ JSON
   run env XRAY_SERVER_IP=203.0.113.10 "${PROJECT_ROOT}/services/xray/client-links.sh" reality-only
 
   [ "$status" -eq 0 ]
-  # Default SNI should be www.microsoft.com
-  [[ "${output}" =~ sni=www.microsoft.com ]]
+  # Default SNI should be www.apple.com
+  [[ "${output}" =~ sni=www.apple.com ]]
 }
 
 @test "client-links defaults to reality-only topology" {

--- a/tests/unit/test_defaults.bats
+++ b/tests/unit/test_defaults.bats
@@ -43,8 +43,8 @@ teardown() {
   [ "${DEFAULT_XRAY_CERT_DIR}" = "/usr/local/etc/xray/certs" ]
 }
 
-@test "DEFAULT_XRAY_SNI is www.microsoft.com" {
-  [ "${DEFAULT_XRAY_SNI}" = "www.microsoft.com" ]
+@test "DEFAULT_XRAY_SNI is www.apple.com" {
+  [ "${DEFAULT_XRAY_SNI}" = "www.apple.com" ]
 }
 
 @test "DEFAULT_XRAY_SNIFFING is true" {

--- a/tests/unit/test_export_command.bats
+++ b/tests/unit/test_export_command.bats
@@ -57,6 +57,23 @@ decode_base64() {
   [[ "${output}" == *"vless://11111111-2222-3333-4444-555555555555@203.0.113.10:443"* ]]
 }
 
+@test "export uri - uses default SNI when not specified" {
+  write_state '{
+    "name": "reality-only",
+    "xray": {
+      "port": 443,
+      "uuid": "11111111-2222-3333-4444-555555555555",
+      "short_id": "abcd1234ef567890",
+      "reality_public_key": "Base64PublicKey=="
+    }
+  }'
+
+  run env XRAY_SERVER_IP=203.0.113.10 "${PROJECT_ROOT}/commands/export.sh" uri
+
+  [ "${status}" -eq 0 ]
+  [[ "${output}" == *"sni=www.apple.com"* ]]
+}
+
 @test "export sub - emits base64 subscription for all links" {
   write_state '{
     "name": "vision-reality",

--- a/tests/unit/test_templates.bats
+++ b/tests/unit/test_templates.bats
@@ -156,7 +156,7 @@ EOF
 @test "templates::export - exports SNI for home template" {
   run bash -c 'source lib/templates.sh && templates::export "home" && echo "SNI=$TEMPLATE_SNI"'
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "SNI=www.microsoft.com" ]]
+  [[ "$output" =~ "SNI=www.apple.com" ]]
 }
 
 @test "templates::export - exports topology-specific ports" {


### PR DESCRIPTION
## Summary

- Change the default Reality SNI from `www.microsoft.com` to `www.apple.com` across default config rendering, client link/export fallbacks, and the built-in `home` template.
- Update install/help/troubleshooting docs so the documented default matches generated behavior.
- Add export coverage for the missing-`reality_sni` fallback path and update default/template/client-link tests.

## Why

The current default generated `sni=www.microsoft.com`, which can mismatch clients expecting the Apple Reality target. This makes a fresh reality-only install default to `www.apple.com` consistently unless operators explicitly override `XRAY_SNI` / `XRAY_REALITY_DEST`.

## Validation

Passed:

```sh
bats -t tests/unit/test_defaults.bats tests/unit/test_templates.bats tests/unit/test_client_links.bats tests/unit/test_export_command.bats
make lint
```

Also ran:

```sh
make fmt && make lint && make test-unit
```

`make test-unit` did not complete cleanly on this macOS host due to existing unrelated failures in `tests/unit/test_fetch_expected_commit.bats`, `tests/unit/test_online_install_script.bats`, and `tests/unit/test_online_uninstall_script.bats`. The online script failures show BSD `sed -i` handling test paths under `/var/folders/...`; these files were not changed by this PR.
